### PR TITLE
Use fixed max senders/receivers due to 10MB limit for max_response_body_size

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -28,6 +28,9 @@ use std::sync::Arc;
 pub mod pull;
 pub mod sync;
 
+pub const MAX_SENDERS: u64 = 1024 * 16;
+pub const MAX_RECEIVERS: u64 = 1024 * 16;
+
 #[rpc(server, namespace = "mantaPay")]
 pub trait MantaPayIndexerApi {
     #[method(name = "pull_ledger_diff")] // no blocking mode, we just query all shards from db
@@ -51,13 +54,22 @@ impl MantaPayIndexerApiServer for MantaPayIndexerServer {
     async fn pull_ledger_diff(
         &self,
         checkpoint: Checkpoint,
-        max_receivers: u64,
-        max_senders: u64,
+        mut max_receivers: u64,
+        mut max_senders: u64,
     ) -> RpcResult<PullResponse> {
+        // Currently, there's a limit on max size of reposne body, 10MB.
+        // So 10MB means the params for (max_receivers, max_senders) is (1024 * 16, 1024 * 16).
+        // If the params exceeds the value, pull_ledger_diff still returns 1024 * 16 utxos at most in one time.
+        // so no error will be returned.
+        if max_receivers > MAX_RECEIVERS || max_senders > MAX_SENDERS {
+            max_receivers = MAX_RECEIVERS;
+            max_senders = MAX_SENDERS;
+        }
+
         let response =
             pull::pull_ledger_diff(&self.db_pool, &checkpoint, max_receivers, max_senders)
                 .await
-                .map_err(|_| JsonRpseeError::AlreadyStopped)?;
+                .map_err(|e| JsonRpseeError::Custom(e.to_string()))?;
 
         Ok(response)
     }


### PR DESCRIPTION
Signed-off-by: Dengjianping <djptux@gmail.com>

Currently, there's a limit on the `max_response_body_size`, which is 10MB(`10485760` bytes).
So by calculation, 10MB means 
```rust
let (max_senders, max_receivers) = (1024 * 16, 1024 * 16);
```
Before serialization, the data in memory is about `3.39`MB.
But after serialization, it will become `9.88`MB, almost 10MB.

So if any number exceeds `1024 * 16`, the server will return an error like this
```
The background task been terminated because: Networking or low-level protocol error: WebSocket connection error: 
message too large: len >= 12951047, maximum = 10485760; restart required
```

Take a look at this PR: https://github.com/paritytech/jsonrpsee/pull/711
and https://github.com/paritytech/jsonrpsee/blob/v0.15.1/core/src/lib.rs#L81

So we have to use fixed values for `(max_senders, max_receivers)`.

`jsonrpsee` is using serde for serialization/deserialization, seems there's no way to change to another crate like `codec` for more compacted data.